### PR TITLE
Validate stdin against IP regex

### DIFF
--- a/gad
+++ b/gad
@@ -181,7 +181,7 @@ check() {
 if [ "$stdin_ip" = "yes" ]; then
   ext_ip_method="standard input"
   read ext_ip
-  ext_ip=`echo "$ext_ip" | sed -n "s/"$ip_regex"/\1/p"`
+  ext_ip=`echo "$ext_ip" | sed -n "s/[^0-9]*"$ip_regex"[^0-9]*/\1/p"`
   if [ -z "$ext_ip" ]; then
     printf "Input does not match expected format: %s\n" "$ip_regex"
     unset ext_ip

--- a/gad
+++ b/gad
@@ -181,6 +181,11 @@ check() {
 if [ "$stdin_ip" = "yes" ]; then
   ext_ip_method="standard input"
   read ext_ip
+  ext_ip=`echo "$ext_ip" | sed -n "s/"$ip_regex"/\1/p"`
+  if [ -z "$ext_ip" ]; then
+    printf "Input does not match expected format: %s\n" "$ip_regex"
+    unset ext_ip
+  fi
 elif [ ! -z "$ext_if" ]; then
   ext_ip_method="ifconfig "$ext_if""
   ext_ip=`ifconfig "$ext_if" | sed -n "s/.*"$inet" \(addr:\)* *"$ip_regex".*/\2/p" | head -1`


### PR DESCRIPTION
Hi Brian. I played around with the stdin method and found it helpful to validate the stdin against the IP regex. It saved me from writing bogus to the zone file. It basically extracts only the IP from stdin or reset the ext_ip to produce an error.