### PR TITLE
Fix ownip empty response when obtaining the A record over ipv6

### DIFF
--- a/gad
+++ b/gad
@@ -359,7 +359,11 @@ elif [ ! -z "$ext_if" ]; then
     ext_ip=$(ifconfig "$ext_if" | sed -n "s/.*${inet} \(addr:\)* *${ip_regex}.*/\2/p" | head -1)
 else
     ext_ip_method="OpenDNS"
-    ext_ip=$(dig "$record_type" +short @resolver1.opendns.com myip.opendns.com)
+    if [ "$record_type" = "A" ]; then
+        ext_ip=$(dig -4 "$record_type" +short @resolver1.opendns.com myip.opendns.com)
+    else
+        ext_ip=$(dig "$record_type" +short @resolver1.opendns.com myip.opendns.com)
+    fi
 fi
 if [ -z "$ext_ip" ]; then
     printf "Failed to determine external IP address with %s. See above error.\\n" "$ext_ip_method"


### PR DESCRIPTION
In the case that a network interface has both ipv4 and ipv6 connectivity if dig invocation for the discovery of a ipv4 `ext_ip` address is done over an ipv6 connection the result comes empty.

The solution is to force the dig invocation to be performed over ipv4 when `record_type` is `A` so that the OpenDNS can correctly identify the `ext_ip`